### PR TITLE
Add simple UI for manual testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The project uses a simple Flask server and an in-memory store for users and bets
 
 ## Setup
 
-1. Install the dependencies:
+1. Ensure you have Python 3.9+ installed and then install the dependencies:
 
 ```bash
 pip install -r requirements.txt
@@ -23,6 +23,9 @@ This will start a local web server on `http://127.0.0.1:5000` with the following
 - `POST /users` – create a user, JSON body `{"username": "name"}`.
 - `POST /bets` – create a bet, JSON body `{"description": "...", "amount": 10, "creator": "alice", "opponent": "bob"}`.
 - `GET /bets` – list all created bets.
+
+After launching the server you can visit `http://127.0.0.1:5000/` to access a small
+testing UI for manually creating users and bets.
 
 ## Running Tests
 

--- a/stakels/server.py
+++ b/stakels/server.py
@@ -1,8 +1,16 @@
-from flask import Flask, jsonify, request
+import os
+from flask import Flask, jsonify, request, send_from_directory
 from .app import BetManager
 
 app = Flask(__name__)
 manager = BetManager()
+BASE_DIR = os.path.dirname(__file__)
+STATIC_DIR = os.path.join(BASE_DIR, 'static')
+
+
+@app.get('/')
+def index():
+    return send_from_directory(STATIC_DIR, 'index.html')
 
 @app.post('/users')
 def create_user():

--- a/stakels/static/index.html
+++ b/stakels/static/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Stakels Test UI</title>
+</head>
+<body>
+<h1>Stakels Test UI</h1>
+<section>
+  <h2>Create User</h2>
+  <input id="username" placeholder="username">
+  <button onclick="createUser()">Create</button>
+  <pre id="createUserResult"></pre>
+</section>
+<section>
+  <h2>Create Bet</h2>
+  <input id="description" placeholder="description">
+  <input id="amount" placeholder="amount" type="number">
+  <input id="creator" placeholder="creator">
+  <input id="opponent" placeholder="opponent">
+  <button onclick="createBet()">Create Bet</button>
+  <pre id="createBetResult"></pre>
+</section>
+<section>
+  <h2>All Bets</h2>
+  <button onclick="fetchBets()">Refresh</button>
+  <pre id="betsResult"></pre>
+</section>
+<script>
+async function createUser() {
+  const username = document.getElementById('username').value;
+  const res = await fetch('/users', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({username})
+  });
+  document.getElementById('createUserResult').innerText = await res.text();
+}
+async function createBet() {
+  const data = {
+    description: document.getElementById('description').value,
+    amount: document.getElementById('amount').value,
+    creator: document.getElementById('creator').value,
+    opponent: document.getElementById('opponent').value
+  };
+  const res = await fetch('/bets', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(data)
+  });
+  document.getElementById('createBetResult').innerText = await res.text();
+}
+async function fetchBets() {
+  const res = await fetch('/bets');
+  document.getElementById('betsResult').innerText = await res.text();
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add minimal HTML page for testing API
- serve the page from `/` via Flask
- document running requirements and mention the new UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f79f002208326acf4cda414815d37